### PR TITLE
Fix tone analyzer over-classification issues

### DIFF
--- a/analyzer.py
+++ b/analyzer.py
@@ -11,12 +11,12 @@ class CommunicationAnalyzer:
     def __init__(self, model: str = None):
         """
         Initialize the analyzer with Ollama LLM.
-        
+
         Args:
             model: Ollama model name (default from config)
         """
         self.model = model or config.OLLAMA_MODEL
-        
+
         # Test Ollama connection
         try:
             ollama.list()
@@ -24,14 +24,14 @@ class CommunicationAnalyzer:
         except Exception as e:
             print(f"Warning: Could not connect to Ollama: {e}")
             print("Make sure Ollama is running: brew install ollama && ollama serve")
-    
+
     def analyze_tone(self, text: str) -> Dict[str, any]:
         """
         Analyze the tone and communication style of text.
-        
+
         Args:
             text: transcribed text to analyze
-            
+
         Returns:
             Dictionary containing tone analysis and suggestions
         """
@@ -43,10 +43,10 @@ class CommunicationAnalyzer:
                 'suggestions': 'Not enough content to analyze',
                 'error': 'insufficient_text'
             }
-        
+
         try:
             prompt = config.ANALYSIS_PROMPT.format(text=text)
-            
+
             response = ollama.generate(
                 model=self.model,
                 prompt=prompt,
@@ -54,18 +54,18 @@ class CommunicationAnalyzer:
                     'temperature': 0.3,  # Lower temperature for more consistent analysis
                 }
             )
-            
+
             # Parse JSON response
             response_text = response['response'].strip()
-            
+
             # Try to extract JSON if it's wrapped in markdown
             if '```json' in response_text:
                 response_text = response_text.split('```json')[1].split('```')[0].strip()
             elif '```' in response_text:
                 response_text = response_text.split('```')[1].split('```')[0].strip()
-            
+
             analysis = json.loads(response_text)
-            
+
             # Ensure all required fields exist (supporting both old and new format)
             analysis.setdefault('tone', analysis.get('emotional_state', 'neutral'))
             analysis.setdefault('emotional_state', analysis.get('tone', 'neutral'))
@@ -77,7 +77,7 @@ class CommunicationAnalyzer:
             analysis.setdefault('coaching_feedback', analysis.get('suggestions', 'No coaching available'))
 
             return analysis
-            
+
         except json.JSONDecodeError as e:
             print(f"Error parsing LLM response: {e}")
             print(f"Response was: {response_text}")
@@ -97,7 +97,7 @@ class CommunicationAnalyzer:
                 'suggestions': 'Analysis unavailable',
                 'error': str(e)
             }
-    
+
     def get_tone_emoji(self, tone: str) -> str:
         """Get emoji representation of emotional state/tone."""
         emoji_map = {
@@ -133,16 +133,16 @@ class CommunicationAnalyzer:
             'repetitive': '🔁'
         }
         return emoji_map.get(social_cue.lower(), '💬')
-    
-    def should_alert(self, tone: str, confidence: float, threshold: float = 0.6) -> bool:
+
+    def should_alert(self, tone: str, confidence: float, threshold: float = 0.7) -> bool:
         """
         Determine if emotional state or social cue should trigger an alert.
-        Lower threshold for autism/ADHD coaching to catch subtle patterns.
+        Higher threshold for autism/ADHD coaching to reduce false positives.
 
         Args:
             tone: detected emotional state or tone
             confidence: confidence level (0-1)
-            threshold: minimum confidence to alert (default 0.6 for more sensitivity)
+            threshold: minimum confidence to alert (default 0.7 for more conservative alerting)
 
         Returns:
             True if alert should be shown
@@ -156,52 +156,52 @@ class CommunicationAnalyzer:
         concerning_patterns = elevated_states + social_concerns
         return tone.lower() in concerning_patterns and confidence >= threshold
 
-    def should_social_cue_alert(self, social_cue: str, confidence: float, threshold: float = 0.6) -> bool:
+    def should_social_cue_alert(self, social_cue: str, confidence: float, threshold: float = 0.7) -> bool:
         """
         Check specifically for social cue alerts.
 
         Args:
             social_cue: detected social cue pattern
             confidence: confidence level (0-1)
-            threshold: minimum confidence to alert
+            threshold: minimum confidence to alert (default 0.7 for conservative alerting)
 
         Returns:
             True if social cue alert should be shown
         """
         concerning_social_cues = ['interrupting', 'dominating', 'too_quiet', 'off_topic', 'repetitive']
         return social_cue.lower() in concerning_social_cues and confidence >= threshold
-    
+
     def generate_summary(self, analyses: list) -> Dict[str, any]:
         """
         Generate summary from multiple analysis results.
-        
+
         Args:
             analyses: list of analysis results
-            
+
         Returns:
             Summary dictionary with trends and insights
         """
         if not analyses:
             return {'error': 'No analyses to summarize'}
-        
+
         # Count tone occurrences
         tone_counts = {}
         total_confidence = 0
         all_suggestions = []
-        
+
         for analysis in analyses:
             tone = analysis.get('tone', 'unknown')
             tone_counts[tone] = tone_counts.get(tone, 0) + 1
             total_confidence += analysis.get('confidence', 0)
-            
+
             suggestion = analysis.get('suggestions', '')
             if suggestion and suggestion not in all_suggestions:
                 all_suggestions.append(suggestion)
-        
+
         # Find dominant tone
         dominant_tone = max(tone_counts, key=tone_counts.get)
         avg_confidence = total_confidence / len(analyses)
-        
+
         return {
             'dominant_tone': dominant_tone,
             'tone_distribution': tone_counts,
@@ -214,28 +214,28 @@ class CommunicationAnalyzer:
 if __name__ == "__main__":
     # Test the analyzer
     analyzer = CommunicationAnalyzer()
-    
+
     # Test with sample texts
     test_texts = [
         "I really appreciate your input on this. That's a great point you've made.",
         "Whatever, I don't really care about that. Let's just move on.",
         "The quarterly results show a 15% increase in revenue, which is in line with our projections."
     ]
-    
+
     print("Testing Communication Analyzer\n")
-    
+
     for i, text in enumerate(test_texts, 1):
         print(f"\nTest {i}: {text}")
         print("-" * 60)
-        
+
         result = analyzer.analyze_tone(text)
-        
+
         emoji = analyzer.get_tone_emoji(result['tone'])
         print(f"Tone: {emoji} {result['tone']} (confidence: {result['confidence']:.2f})")
         print(f"Suggestions: {result['suggestions']}")
-        
+
         if result.get('key_indicators'):
             print(f"Key indicators: {', '.join(result['key_indicators'])}")
-        
+
         if analyzer.should_alert(result['tone'], result['confidence']):
             print("⚠️  Alert: Potentially problematic tone detected")

--- a/config.py
+++ b/config.py
@@ -14,7 +14,7 @@ DEVICE = "cpu"  # Options: cpu, cuda
 
 # Analysis Settings
 OLLAMA_MODEL = "gemma2:2b"  # LLM model for tone analysis
-MIN_WORDS_FOR_ANALYSIS = 5  # Minimum words before analyzing
+MIN_WORDS_FOR_ANALYSIS = 15  # Minimum words before analyzing (need sufficient context)
 
 # Speaking Pace Thresholds
 PACE_TOO_FAST = 180  # Words per minute
@@ -34,26 +34,25 @@ USE_MICROPHONE_INPUT = True  # True = analyze YOUR speech, False = analyze Teams
 BLACKHOLE_DEVICE_INDEX = None  # Will auto-detect if None
 MICROPHONE_DEVICE_INDEX = None  # Will prompt for selection if None
 
-# Analysis Prompt Template
-ANALYSIS_PROMPT = """Analyze this meeting transcript segment for communication tone. Be conservative and precise in your assessment:
+# Analysis Prompt Template - Specialized for Autism/ADHD Social Coaching
+ANALYSIS_PROMPT = """Analyze this meeting transcript for social cues and emotional regulation patterns.
+Focus on objective assessment to help someone with autism and ADHD understand their communication.
 
-"{text}"
-
-Guidelines for tone classification:
-- NEUTRAL: Default for factual statements, data presentations, or emotionally flat content
-- SUPPORTIVE: Clear encouragement, appreciation, or positive reinforcement (e.g., "great idea", "I appreciate")
-- DISMISSIVE: Explicit rejection or disregard (e.g., "whatever", "I don't care", outright dismissal)
-- AGGRESSIVE: Hostile language, personal attacks, or confrontational phrasing
-- PASSIVE: Withdrawn, reluctant participation, or avoiding responsibility
-
-IMPORTANT:
-- Factual statements and brief responses should typically be NEUTRAL
-- Only flag as problematic (dismissive/aggressive/passive) when tone is clearly evident
-- Be conservative with confidence scores - use lower confidence (0.3-0.6) for borderline cases
-- Higher confidence (0.7+) only for clear, unambiguous tone indicators
+Text: "{text}"
 
 Provide a JSON response with:
-1. tone: "supportive", "dismissive", "neutral", "aggressive", or "passive"
-2. confidence: 0.0-1.0 (be conservative)
-3. key_indicators: specific phrases that influenced the assessment
-4. suggestions: brief feedback (one sentence) or "No specific feedback needed" for neutral content"""
+1. emotional_state: "calm", "engaged", "elevated", "intense", "rapid", "distracted", or "overwhelmed"
+2. social_cues: "appropriate", "interrupting", "dominating", "monotone", "too_quiet", "off_topic", or "repetitive"
+3. speech_pattern: "normal", "rushed", "rambling", "clear", "hesitant", "loud", or "quiet"
+4. confidence: 0.0-1.0 (how certain you are of the assessment)
+5. key_indicators: list of specific words/phrases that support your assessment
+6. coaching_feedback: practical, supportive suggestion if needed (one sentence, or "Continue as you are" if appropriate)
+
+Assessment guidelines:
+- Default to "calm" and "appropriate" for normal conversational speech
+- Only flag "intense" or "elevated" if there are clear indicators like excitement, urgency, or emotional language
+- Consider context - sharing accomplishments or explaining technical topics is often normal enthusiasm
+- "engaged" is positive - someone actively participating in discussion
+- Focus on patterns, not single words or phrases
+
+Be conservative in flagging issues - most conversation should be assessed as appropriate."""


### PR DESCRIPTION
- Increase MIN_WORDS_FOR_ANALYSIS from 5 to 15 words for better context
- Rebalance analysis prompt to default to neutral/positive states
- Raise confidence thresholds from 0.6 to 0.7 to reduce false alerts
- Add explicit guidance for conservative assessment
- Prioritize 'calm' and 'appropriate' as default states
- Improve context awareness for normal enthusiasm vs problematic intensity