### PR TITLE
Configure Copilot triage to respond to Codex bot comments

### DIFF
--- a/.github/copilot/config.yml
+++ b/.github/copilot/config.yml
@@ -1,0 +1,3 @@
+triage:
+  respond-to-bots:
+    - chatgpt-codex-connector[bot]


### PR DESCRIPTION
This pull request adds a `.github/copilot/config.yml` file that configures Copilot to automatically respond to comments from the chatgpt-codex-connector bot.