### PR TITLE
ci: configure Copilot triage to respond to Codex bot comments

### DIFF
--- a/.github/copilot/config.yml
+++ b/.github/copilot/config.yml
@@ -1,0 +1,3 @@
+triage:
+  respond-to-bots:
+    - chatgpt-codex-connector[bot]


### PR DESCRIPTION
This PR adds a .github/copilot/config.yml file to configure Copilot triage to respond to comments made by the chatgpt-codex-connector bot.