### PR TITLE
ci: add configuration for bot response triage in Copilot

### DIFF
--- a/.github/copilot/config.yml
+++ b/.github/copilot/config.yml
@@ -1,0 +1,3 @@
+triage:
+  respond-to-bots:
+    - chatgpt-codex-connector[bot]


### PR DESCRIPTION
Introduce a triage configuration to manage responses from specific bots in Copilot.